### PR TITLE
Allow readonly request bodies

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import { assert as assertType, _ } from "spec.ts";
+import { DeepReadonly } from "../utils";
+
+describe("utils", () => {
+  it("should make deep readonly types", () => {
+    type ReadonlyArray = DeepReadonly<string[]>;
+    assertType(_ as ReadonlyArray, _ as readonly string[]);
+
+    type ReadonlyObj = DeepReadonly<{ foo: string }>;
+    assertType(_ as ReadonlyObj, _ as { readonly foo: string });
+
+    const u = {
+      foo: {
+        bar: ["baz", "quux"],
+      },
+    };
+    assertType(u, _ as { foo: { bar: string[] } });
+    assertType(
+      _ as DeepReadonly<typeof u>,
+      _ as { readonly foo: { readonly bar: readonly string[] } }
+    );
+  });
+});

--- a/src/typed-request.ts
+++ b/src/typed-request.ts
@@ -2,10 +2,10 @@
 
 import { compile } from "path-to-regexp";
 
-import { ExtractRouteParams, SafeKey, HTTPVerb, Unionize } from "./utils";
+import { ExtractRouteParams, SafeKey, HTTPVerb, Unionize, DeepReadonly } from "./utils";
 
 type ExtractRouteParamsVarArgs<T extends string> =
-  {} extends ExtractRouteParams<T> ? [] : [params: ExtractRouteParams<T>];
+  {} extends ExtractRouteParams<T> ? [] : [params: Readonly<ExtractRouteParams<T>>];
 
 /** Utility for safely constructing API URLs */
 export function apiUrlMaker<API>(prefix = '') {
@@ -58,7 +58,7 @@ export function typedApi<API>(options?: Options) {
   ) => {
     type Params = ExtractRouteParams<Path & string>;
     type Endpoint = API[Path][Method];
-    type Request = SafeKey<Endpoint, "request">;
+    type Request = DeepReadonly<SafeKey<Endpoint, "request">>;
     type Response = SafeKey<Endpoint, "response">;
     const makeUrl = urlMaker(endpoint);
     return (queryParams: Params, body: Request): Promise<Response> =>
@@ -79,7 +79,7 @@ export function typedApi<API>(options?: Options) {
     post: <Path extends PostPaths>(endpoint: Path) => {
       type Params = ExtractRouteParams<Path & string>;
       type Endpoint = SafeKey<API[Path], "post">;
-      type Request = SafeKey<Endpoint, "request">;
+      type Request = DeepReadonly<SafeKey<Endpoint, "request">>;
       type Response = SafeKey<Endpoint, "response">;
       return (params: Params, body: Request): Promise<Response> =>
         request(endpoint, "post" as any)(params, body);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,3 +15,12 @@ export type ExtractRouteParams<T extends string> =
 export type HTTPVerb = 'get' | 'post' | 'put' | 'delete' | 'patch';
 
 export type Unionize<T> = {[k in keyof T]: {k: k, v: T[k]}}[keyof T];
+
+export type Primitive = string | number | boolean | bigint | symbol | undefined | null;
+
+/** Based on ts-essentials, but reduced to only JSON-compatible types */
+export type DeepReadonly<T> = T extends Primitive
+  ? T
+  : T extends {}
+  ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+  : Readonly<T>;


### PR DESCRIPTION
crosswalk doesn't modify your request body, so it shouldn't require a mutable value.

It seems like the same would apply to path parameters, but I didn't get an error when I passed in a readonly object for those.