### PR TITLE
Add wrappers for all verbs

### DIFF
--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -1,4 +1,4 @@
-import { APISpec, Endpoint, GetEndpoint } from "../api-spec";
+import { Endpoint, GetEndpoint } from "../api-spec";
 
 export interface User {
   id: string;

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -1,4 +1,4 @@
-import { Endpoint, GetEndpoint } from "../api-spec";
+import { APISpec, Endpoint, GetEndpoint } from "../api-spec";
 
 export interface User {
   id: string;

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -163,25 +163,3 @@ test('invalid registrations should be type errors', () => {
   // @ts-expect-error should be userId, not id
   router.get('/users/:userId', async ({id}) => users[0]);
 });
-
-test('autocomplete', () => {
-  interface API {
-    '/path/to/:foo/:bar/baz': {
-      get: GetEndpoint<{}>;
-      post: Endpoint<null, {}>;
-    }
-  }
-
-  const app = express();
-  const router = new TypedRouter<API>(app);
-
-  router.get('/path/to/:foo/:bar/baz', async ({foo, bar}, req, res) => {
-    req.params.foo;
-    req.res?.json()
-    return {};
-  });
-
-  router.registerEndpoint('post', '/path/to/:foo/:bar/baz', async ({foo}, body, request, response) => {
-    return {};
-  });
-});

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -6,7 +6,6 @@ import request from 'supertest';
 import {API, User} from './api';
 import apiSchemaJson from './api.schema.json';
 import {HTTPError, TypedRouter} from '../typed-router';
-import { Endpoint, GetEndpoint } from '../api-spec';
 
 test('TypedRouter', async () => {
   const app = express();

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -6,6 +6,7 @@ import request from 'supertest';
 import {API, User} from './api';
 import apiSchemaJson from './api.schema.json';
 import {HTTPError, TypedRouter} from '../typed-router';
+import { Endpoint, GetEndpoint } from '../api-spec';
 
 test('TypedRouter', async () => {
   const app = express();
@@ -161,4 +162,18 @@ test('invalid registrations should be type errors', () => {
 
   // @ts-expect-error should be userId, not id
   router.get('/users/:userId', async ({id}) => users[0]);
+});
+
+test('autocomplete', () => {
+  interface API {
+    '/path/to/:foo/:bar:/baz': {
+      get: GetEndpoint<null>;
+      post: Endpoint<null, null>;
+    }
+  }
+
+  const app = express();
+  const router = new TypedRouter<API>(app);
+
+  router.get('/path/to/:foo/:bar:/baz',
 });

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -175,11 +175,13 @@ test('autocomplete', () => {
   const app = express();
   const router = new TypedRouter<API>(app);
 
-  router.get('/path/to/:foo/:bar/baz', async ({foo, bar}) => {
+  router.get('/path/to/:foo/:bar/baz', async ({foo, bar}, req, res) => {
+    req.params.foo;
+    req.res?.json()
     return {};
   });
 
-  router.registerEndpoint('post', '/path/to/:foo/:bar/baz', async ({foo}) => {
+  router.registerEndpoint('post', '/path/to/:foo/:bar/baz', async ({foo}, body, request, response) => {
     return {};
   });
 });

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -166,14 +166,20 @@ test('invalid registrations should be type errors', () => {
 
 test('autocomplete', () => {
   interface API {
-    '/path/to/:foo/:bar:/baz': {
-      get: GetEndpoint<null>;
-      post: Endpoint<null, null>;
+    '/path/to/:foo/:bar/baz': {
+      get: GetEndpoint<{}>;
+      post: Endpoint<null, {}>;
     }
   }
 
   const app = express();
   const router = new TypedRouter<API>(app);
 
-  router.get('/path/to/:foo/:bar:/baz',
+  router.get('/path/to/:foo/:bar/baz', async ({foo, bar}) => {
+    return {};
+  });
+
+  router.registerEndpoint('post', '/path/to/:foo/:bar/baz', async ({foo}) => {
+    return {};
+  });
 });

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -23,10 +23,9 @@ test('TypedRouter', async () => {
     age: 41,
   }];
 
-  // This is async, so it does return a promise.
   router.get('/users', async () => ({users}));
 
-  router.registerEndpoint('post', '/users', async ({}, user, request, response) => {
+  router.post('/users', async ({}, user, request, response) => {
     assertType(user, _ as {age: number; name: string;});
     assertType(request.params, _ as {});
     assertType(request.body, _ as {age: number; name: string;});

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -4,3 +4,11 @@ export interface Endpoint<Request, Response> {
 }
 
 export type GetEndpoint<Response> = Endpoint<null, Response>;
+
+export type HTTPVerb = 'get' | 'post' | 'put' | 'delete' | 'patch';
+
+export interface APISpec {
+  [path: string]: {
+    [method in HTTPVerb]?: Endpoint<any, any>;
+  }
+}

--- a/src/typed-router.ts
+++ b/src/typed-router.ts
@@ -22,6 +22,14 @@ type RequestParams = Parameters<express.RequestHandler>;
 
 type AnyEndpoint = Endpoint<any, any>;
 
+type ExpressRequest<Path extends string, Spec> = unknown & express.Request<
+  ExtractRouteParams<Path>,
+  SafeKey<Spec, 'response'>,
+  SafeKey<Spec, 'request'>
+>;
+
+type ExpressResponse<Spec> = unknown & express.Response<SafeKey<Spec, 'response'>>;
+
 const registerWithBody = <Method extends HTTPVerb, API>(
   method: Method, router: TypedRouter<API>
 ) =>
@@ -33,12 +41,8 @@ const registerWithBody = <Method extends HTTPVerb, API>(
     handler: (
       params: ExtractRouteParams<Path>,
       body: SafeKey<Spec, 'request'>,
-      request: express.Request<
-        ExtractRouteParams<Path>,
-        SafeKey<Spec, 'response'>,
-        SafeKey<Spec, 'request'>
-      >,
-      response: express.Response<SafeKey<Spec, 'response'>>,
+      request: ExpressRequest<Path, Spec>,
+      response: ExpressResponse<Spec>,
     ) => Promise<Spec extends AnyEndpoint ? Spec['response'] : never>
   ) => {
     router.registerEndpoint(method, route as any, handler as any);
@@ -54,11 +58,8 @@ const registerWithoutBody = <Method extends HTTPVerb, API>(
     route: Path,
     handler: (
       params: ExtractRouteParams<Path>,
-      request: express.Request<
-        ExtractRouteParams<Path>,
-        SafeKey<Spec, 'response'>
-      >,
-      response: express.Response<SafeKey<Spec, 'response'>>,
+      request: ExpressRequest<Path, Spec>,
+      response: ExpressResponse<Spec>,
     ) => Promise<Spec extends AnyEndpoint ? Spec['response'] : never>
   ) => {
     router.registerEndpoint(
@@ -102,12 +103,8 @@ export class TypedRouter<API> {
     handler: (
       params: ExtractRouteParams<Path>,
       body: SafeKey<Spec, 'request'>,
-      request: express.Request<
-        ExtractRouteParams<Path>,
-        SafeKey<Spec, 'response'>,
-        SafeKey<Spec, 'request'>
-      >,
-      response: express.Response<SafeKey<Spec, 'response'>>,
+      request: ExpressRequest<Path, Spec>,
+      response: ExpressResponse<Spec>,
     ) => Promise<Spec extends AnyEndpoint ? Spec['response'] : never>
   ) {
     const validate = this.getValidator(route, method);

--- a/src/typed-router.ts
+++ b/src/typed-router.ts
@@ -67,9 +67,19 @@ const registerWithBody = <Method extends HTTPVerb, API>(
 const registerWithoutBody = <Method extends HTTPVerb, API>(
   method: Method, router: TypedRouter<API>
 ) =>
-  <Path extends PathsForMethod<API, Method>>(
+  <
+  Path extends PathsForMethod<API, Method>,
+  Spec extends SafeKey<API[Path], Method> = SafeKey<API[Path], Method>
+  >(
     route: Path,
-    handler: unknown & HandlerWithoutBody<API, Method, Path>
+    handler: (
+      params: ExtractRouteParams<Path>,
+      request: express.Request<
+        ExtractRouteParams<Path>,
+        SafeKey<Spec, 'response'>
+      >,
+      response: express.Response<SafeKey<Spec, 'response'>>,
+    ) => Promise<Spec extends AnyEndpoint ? Spec['response'] : never>
   ) => {
     router.registerEndpoint(
       method,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
+import { HTTPVerb } from "./api-spec";
+
 /** Like T[K], but doesn't require K be assignable to keyof T */
-export type SafeKey<T, K extends string> = T[K & keyof T];
+export type SafeKey<T, K extends PropertyKey> = T[K & keyof T];
 
 // TODO: Look into fancier variation from https://ja.nsommer.dk/articles/type-checked-url-router.html
 /** Extract params from an express path (e.g. '/students/:studentId'). */
@@ -12,8 +14,6 @@ export type ExtractRouteParams<T extends string> =
   ? {[k in Param]: string}
   : {};
 
-export type HTTPVerb = 'get' | 'post' | 'put' | 'delete' | 'patch';
-
 export type Unionize<T> = {[k in keyof T]: {k: k, v: T[k]}}[keyof T];
 
 export type Primitive = string | number | boolean | bigint | symbol | undefined | null;
@@ -24,3 +24,6 @@ export type DeepReadonly<T> = T extends Primitive
   : T extends {}
   ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
   : Readonly<T>;
+
+export type PathsForMethod<API, Method extends HTTPVerb> =
+  Extract<Unionize<API>, { v: Record<Method, any> }>["k"] & keyof API & string;


### PR DESCRIPTION
The `get` and `delete` methods don't accept bodies. If you really need that, you can use `registerEndpoint`.

I tried to factor out as much shared code as I could, but it gets tricky to do that while retaining nice autocomplete.

![image](https://user-images.githubusercontent.com/98301/99908719-26b30780-2cb2-11eb-9683-2e3e370bbbe4.png)

vs. showing `RequestWithoutBody` or another internal type alias.