### PR TITLE
Support typing for query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ const fredUrl = getUserUrl({userId: 'fred'});
 To ensure that your users hit API endpoints with the correct payloads, use
 `typescript-json-schema` to convert your API definition to JSON Schema:
 
-    typescript-json-schema --required --strictNullChecks api.ts API --out api.schema.json
+    typescript-json-schema --required --strictNullChecks --noExtraProps api.ts API --out api.schema.json
 
 Then pass this to the `TypeRouter` when you create it in `server.ts`:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import type {Endpoint, GetEndpoint} from 'crosswalk/dist/api-spec';
 
 export interface API {
   '/users': {
-    get: GetEndpoint<UsersResponse>;
+    get: GetEndpoint<UsersResponse, {nameIncludes: string}>;
     post: Endpoint<CreateUserRequest, User>;
   };
   '/users/:userId': {
@@ -60,7 +60,7 @@ import {API} from './api';
 import {TypedRouter} from 'crosswalk';
 
 export function registerAPI(router: TypedRouter<API>) {
-  router.get('/users', async () => users;
+  router.get('/users', async ({}, req, res, {nameIncludes}) => filterUsersByName(users, nameIncludes));
   router.post('/users', async ({}, userInput) => createUser(userInput));
   router.get('/users/:userId', async ({userId}) => getUserById(userId));
 }
@@ -81,6 +81,7 @@ There are a few things you get by doing this:
 - A definition of your API's shape in one place using TypeScript's type system.
 - A check that you've only implemented endpoints that are in the API definition.
 - Types for route parameters (via TypeScript 4.1's template literal types)
+- Types for query parameters (and automatic coercion of non-string parameters)
 - A check that each endpoint's implementation returns a Promise for the
   expected response type.
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
   "author": "Dan Vanderkam <danvk@sidewalklabs.com>",
   "license": "MIT",
   "scripts": {
-    "prepare": "install-peers",
+    "postinstall": "yarn install-peers",
+    "prepare": "yarn build",
     "test": "jest",
     "lint": "prettier --check src/**/*.ts",
-    "prettier": "prettier --write src/**/*.ts"
+    "prettier": "prettier --write src/**/*.ts",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,10 @@
   "author": "Dan Vanderkam <danvk@sidewalklabs.com>",
   "license": "MIT",
   "scripts": {
-    "postinstall": "yarn install-peers",
-    "prepare": "yarn build",
+    "prepare": "install-peers",
     "test": "jest",
     "lint": "prettier --check src/**/*.ts",
-    "prettier": "prettier --write src/**/*.ts",
-    "build": "tsc"
+    "prettier": "prettier --write src/**/*.ts"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -58,6 +58,27 @@ Object {
     "version": "",
   },
   "paths": Object {
+    "/random": Object {
+      "get": Object {
+        "responses": Object {
+          "200": Object {
+            "schema": Object {
+              "additionalProperties": false,
+              "properties": Object {
+                "random": Object {
+                  "type": "number",
+                },
+              },
+              "required": Array [
+                "random",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "summary": "Get a random number",
+      },
+    },
     "/users": Object {
       "get": Object {
         "parameters": Array [

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -132,6 +132,13 @@ Object {
           },
           Object {
             "in": "query",
+            "name": "nameIncludes",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+          Object {
+            "in": "query",
             "name": "suffix",
             "schema": Object {
               "type": "string",

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -143,6 +143,13 @@ Object {
             "name": "userId",
             "type": "string",
           },
+          Object {
+            "in": "query",
+            "name": "firstName",
+            "schema": Object {
+              "type": "string",
+            },
+          },
         ],
         "responses": Object {
           "200": Object {

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -63,7 +63,14 @@ Object {
         "parameters": Array [
           Object {
             "in": "query",
-            "name": "name",
+            "name": "minAge",
+            "schema": Object {
+              "type": "number",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "nameIncludes",
             "schema": Object {
               "type": "string",
             },

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -60,6 +60,15 @@ Object {
   "paths": Object {
     "/users": Object {
       "get": Object {
+        "parameters": Array [
+          Object {
+            "in": "query",
+            "name": "name",
+            "schema": Object {
+              "type": "string",
+            },
+          },
+        ],
         "responses": Object {
           "200": Object {
             "schema": Object {

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -43,6 +43,9 @@ Object {
         "name": Object {
           "type": "string",
         },
+        "suffix": Object {
+          "type": "string",
+        },
       },
       "required": Array [
         "age",
@@ -125,6 +128,13 @@ Object {
             "name": "body",
             "schema": Object {
               "$ref": "#/definitions/Pick<User,\\"name\\"|\\"age\\">",
+            },
+          },
+          Object {
+            "in": "query",
+            "name": "suffix",
+            "schema": Object {
+              "type": "string",
             },
           },
         ],

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -22,11 +22,17 @@
             ],
             "type": "object"
         },
-        "Endpoint<Pick<User,\"name\"|\"age\">,User,null>": {
+        "Endpoint<Pick<User,\"name\"|\"age\">,User,{suffix?:string|undefined;}>": {
             "additionalProperties": false,
             "properties": {
                 "query": {
-                    "type": "null"
+                    "additionalProperties": false,
+                    "properties": {
+                        "suffix": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "request": {
                     "$ref": "#/definitions/Pick<User,\"name\"|\"age\">"
@@ -228,6 +234,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "suffix": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -260,7 +269,7 @@
                     "description": "Get the full list of users"
                 },
                 "post": {
-                    "$ref": "#/definitions/Endpoint<Pick<User,\"name\"|\"age\">,User,null>",
+                    "$ref": "#/definitions/Endpoint<Pick<User,\"name\"|\"age\">,User,{suffix?:string|undefined;}>",
                     "description": "Create a new user"
                 }
             },

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -22,12 +22,15 @@
             ],
             "type": "object"
         },
-        "Endpoint<Pick<User,\"name\"|\"age\">,User,{suffix?:string|undefined;}>": {
+        "Endpoint<Pick<User,\"name\"|\"age\">,User,{nameIncludes?:string|undefined;suffix?:string|undefined;}>": {
             "additionalProperties": false,
             "properties": {
                 "query": {
                     "additionalProperties": false,
                     "properties": {
+                        "nameIncludes": {
+                            "type": "string"
+                        },
                         "suffix": {
                             "type": "string"
                         }
@@ -269,7 +272,7 @@
                     "description": "Get the full list of users"
                 },
                 "post": {
-                    "$ref": "#/definitions/Endpoint<Pick<User,\"name\"|\"age\">,User,{suffix?:string|undefined;}>",
+                    "$ref": "#/definitions/Endpoint<Pick<User,\"name\"|\"age\">,User,{nameIncludes?:string|undefined;suffix?:string|undefined;}>",
                     "description": "Create a new user"
                 }
             },

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -93,11 +93,17 @@
             ],
             "type": "object"
         },
-        "GetEndpoint<User,null>": {
+        "GetEndpoint<User,{firstName?:string|undefined;}>": {
             "additionalProperties": false,
             "properties": {
                 "query": {
-                    "type": "null"
+                    "additionalProperties": false,
+                    "properties": {
+                        "firstName": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 },
                 "request": {
                     "type": "null"
@@ -113,7 +119,7 @@
             ],
             "type": "object"
         },
-        "GetEndpoint<{users:User[];},{name:string;}>": {
+        "GetEndpoint<{users:User[];},{name?:string|undefined;}>": {
             "additionalProperties": false,
             "properties": {
                 "query": {
@@ -123,9 +129,6 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "name"
-                    ],
                     "type": "object"
                 },
                 "request": {
@@ -208,7 +211,7 @@
             "additionalProperties": false,
             "properties": {
                 "get": {
-                    "$ref": "#/definitions/GetEndpoint<{users:User[];},{name:string;}>",
+                    "$ref": "#/definitions/GetEndpoint<{users:User[];},{name?:string|undefined;}>",
                     "description": "Get the full list of users"
                 },
                 "post": {
@@ -229,7 +232,7 @@
                     "$ref": "#/definitions/Endpoint<{},User,null>"
                 },
                 "get": {
-                    "$ref": "#/definitions/GetEndpoint<User,null>"
+                    "$ref": "#/definitions/GetEndpoint<User,{firstName?:string|undefined;}>"
                 },
                 "patch": {
                     "$ref": "#/definitions/Endpoint<Partial<Pick<User,\"name\"|\"age\">>,User,null>",

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -2,9 +2,12 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
-        "Endpoint<Partial<Pick<User,\"name\"|\"age\">>,User>": {
+        "Endpoint<Partial<Pick<User,\"name\"|\"age\">>,User,null>": {
             "additionalProperties": false,
             "properties": {
+                "query": {
+                    "type": "null"
+                },
                 "request": {
                     "$ref": "#/definitions/Partial<Pick<User,\"name\"|\"age\">>"
                 },
@@ -13,14 +16,18 @@
                 }
             },
             "required": [
+                "query",
                 "request",
                 "response"
             ],
             "type": "object"
         },
-        "Endpoint<Pick<User,\"name\"|\"age\">,User>": {
+        "Endpoint<Pick<User,\"name\"|\"age\">,User,null>": {
             "additionalProperties": false,
             "properties": {
+                "query": {
+                    "type": "null"
+                },
                 "request": {
                     "$ref": "#/definitions/Pick<User,\"name\"|\"age\">"
                 },
@@ -29,14 +36,18 @@
                 }
             },
             "required": [
+                "query",
                 "request",
                 "response"
             ],
             "type": "object"
         },
-        "Endpoint<{name?:string|undefined;age?:number|undefined;},User>": {
+        "Endpoint<{name?:string|undefined;age?:number|undefined;},User,null>": {
             "additionalProperties": false,
             "properties": {
+                "query": {
+                    "type": "null"
+                },
                 "request": {
                     "additionalProperties": false,
                     "properties": {
@@ -54,14 +65,18 @@
                 }
             },
             "required": [
+                "query",
                 "request",
                 "response"
             ],
             "type": "object"
         },
-        "Endpoint<{},User>": {
+        "Endpoint<{},User,null>": {
             "additionalProperties": false,
             "properties": {
+                "query": {
+                    "type": "null"
+                },
                 "request": {
                     "properties": {
                     },
@@ -72,14 +87,18 @@
                 }
             },
             "required": [
+                "query",
                 "request",
                 "response"
             ],
             "type": "object"
         },
-        "GetEndpoint<User>": {
+        "GetEndpoint<User,null>": {
             "additionalProperties": false,
             "properties": {
+                "query": {
+                    "type": "null"
+                },
                 "request": {
                     "type": "null"
                 },
@@ -88,14 +107,27 @@
                 }
             },
             "required": [
+                "query",
                 "request",
                 "response"
             ],
             "type": "object"
         },
-        "GetEndpoint<{users:User[];}>": {
+        "GetEndpoint<{users:User[];},{name:string;}>": {
             "additionalProperties": false,
             "properties": {
+                "query": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object"
+                },
                 "request": {
                     "type": "null"
                 },
@@ -116,6 +148,7 @@
                 }
             },
             "required": [
+                "query",
                 "request",
                 "response"
             ],
@@ -175,11 +208,11 @@
             "additionalProperties": false,
             "properties": {
                 "get": {
-                    "$ref": "#/definitions/GetEndpoint<{users:User[];}>",
+                    "$ref": "#/definitions/GetEndpoint<{users:User[];},{name:string;}>",
                     "description": "Get the full list of users"
                 },
                 "post": {
-                    "$ref": "#/definitions/Endpoint<Pick<User,\"name\"|\"age\">,User>",
+                    "$ref": "#/definitions/Endpoint<Pick<User,\"name\"|\"age\">,User,null>",
                     "description": "Create a new user"
                 }
             },
@@ -193,17 +226,17 @@
             "additionalProperties": false,
             "properties": {
                 "delete": {
-                    "$ref": "#/definitions/Endpoint<{},User>"
+                    "$ref": "#/definitions/Endpoint<{},User,null>"
                 },
                 "get": {
-                    "$ref": "#/definitions/GetEndpoint<User>"
+                    "$ref": "#/definitions/GetEndpoint<User,null>"
                 },
                 "patch": {
-                    "$ref": "#/definitions/Endpoint<Partial<Pick<User,\"name\"|\"age\">>,User>",
+                    "$ref": "#/definitions/Endpoint<Partial<Pick<User,\"name\"|\"age\">>,User,null>",
                     "description": "Edit an existing user"
                 },
                 "put": {
-                    "$ref": "#/definitions/Endpoint<{name?:string|undefined;age?:number|undefined;},User>"
+                    "$ref": "#/definitions/Endpoint<{name?:string|undefined;age?:number|undefined;},User,null>"
                 }
             },
             "required": [

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -119,6 +119,35 @@
             ],
             "type": "object"
         },
+        "GetEndpoint<{random:number;},null>": {
+            "additionalProperties": false,
+            "properties": {
+                "query": {
+                    "type": "null"
+                },
+                "request": {
+                    "type": "null"
+                },
+                "response": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "random": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "random"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "query",
+                "request",
+                "response"
+            ],
+            "type": "object"
+        },
         "GetEndpoint<{users:User[];},{nameIncludes?:string|undefined;minAge?:number|undefined;}>": {
             "additionalProperties": false,
             "properties": {
@@ -210,6 +239,19 @@
         }
     },
     "properties": {
+        "/random": {
+            "additionalProperties": false,
+            "properties": {
+                "get": {
+                    "$ref": "#/definitions/GetEndpoint<{random:number;},null>",
+                    "description": "Get a random number"
+                }
+            },
+            "required": [
+                "get"
+            ],
+            "type": "object"
+        },
         "/users": {
             "additionalProperties": false,
             "properties": {
@@ -255,6 +297,7 @@
         }
     },
     "required": [
+        "/random",
         "/users",
         "/users/:userId"
     ],

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -119,13 +119,16 @@
             ],
             "type": "object"
         },
-        "GetEndpoint<{users:User[];},{name?:string|undefined;}>": {
+        "GetEndpoint<{users:User[];},{nameIncludes?:string|undefined;minAge?:number|undefined;}>": {
             "additionalProperties": false,
             "properties": {
                 "query": {
                     "additionalProperties": false,
                     "properties": {
-                        "name": {
+                        "minAge": {
+                            "type": "number"
+                        },
+                        "nameIncludes": {
                             "type": "string"
                         }
                     },
@@ -211,7 +214,7 @@
             "additionalProperties": false,
             "properties": {
                 "get": {
-                    "$ref": "#/definitions/GetEndpoint<{users:User[];},{name?:string|undefined;}>",
+                    "$ref": "#/definitions/GetEndpoint<{users:User[];},{nameIncludes?:string|undefined;minAge?:number|undefined;}>",
                     "description": "Get the full list of users"
                 },
                 "post": {

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -3,6 +3,7 @@ import {Endpoint, GetEndpoint} from '../api-spec';
 export interface User {
   id: string;
   name: string;
+  suffix?: string;
   age: number;
 }
 
@@ -17,7 +18,7 @@ export interface API {
     /** Get the full list of users */
     get: GetEndpoint<{users: User[]}, {nameIncludes?: string; minAge?: number}>;
     /** Create a new user */
-    post: Endpoint<CreateUserRequest, User>;
+    post: Endpoint<CreateUserRequest, User, {suffix?: string}>;
   };
   '/users/:userId': {
     get: GetEndpoint<User, {firstName?: string}>;

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -9,6 +9,10 @@ export interface User {
 export type CreateUserRequest = Pick<User, 'name' | 'age'>;
 
 export interface API {
+  '/random': {
+    /** Get a random number */
+    get: GetEndpoint<{random: number}>;
+  };
   '/users': {
     /** Get the full list of users */
     get: GetEndpoint<{users: User[]}, {nameIncludes?: string; minAge?: number}>;

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -11,12 +11,12 @@ export type CreateUserRequest = Pick<User, 'name' | 'age'>;
 export interface API {
   '/users': {
     /** Get the full list of users */
-    get: GetEndpoint<{users: User[]}, {name: string}>;
+    get: GetEndpoint<{users: User[]}, {name?: string}>;
     /** Create a new user */
     post: Endpoint<CreateUserRequest, User>;
   };
   '/users/:userId': {
-    get: GetEndpoint<User>;
+    get: GetEndpoint<User, {firstName?: string}>;
     /** Edit an existing user */
     patch: Endpoint<Partial<CreateUserRequest>, User>;
     put: Endpoint<{name?: string; age?: number}, User>;

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -11,7 +11,7 @@ export type CreateUserRequest = Pick<User, 'name' | 'age'>;
 export interface API {
   '/users': {
     /** Get the full list of users */
-    get: GetEndpoint<{users: User[]}, {name?: string}>;
+    get: GetEndpoint<{users: User[]}, {nameIncludes?: string; minAge?: number}>;
     /** Create a new user */
     post: Endpoint<CreateUserRequest, User>;
   };

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -18,7 +18,7 @@ export interface API {
     /** Get the full list of users */
     get: GetEndpoint<{users: User[]}, {nameIncludes?: string; minAge?: number}>;
     /** Create a new user */
-    post: Endpoint<CreateUserRequest, User, {suffix?: string}>;
+    post: Endpoint<CreateUserRequest, User, {nameIncludes?: string; suffix?: string}>;
   };
   '/users/:userId': {
     get: GetEndpoint<User, {firstName?: string}>;

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -11,7 +11,7 @@ export type CreateUserRequest = Pick<User, 'name' | 'age'>;
 export interface API {
   '/users': {
     /** Get the full list of users */
-    get: GetEndpoint<{users: User[]}>;
+    get: GetEndpoint<{users: User[]}, {name: string}>;
     /** Create a new user */
     post: Endpoint<CreateUserRequest, User>;
   };

--- a/src/__tests__/typed-request.test.ts
+++ b/src/__tests__/typed-request.test.ts
@@ -46,11 +46,11 @@ describe('typed requests', () => {
       const getUserById = api.get('/users/:userId');
 
       mockFetcher.mockReturnValueOnce(Promise.resolve({users: []}));
-      const users = await getUsers();
+      const users = await getUsers({}, {name: 'red'});
       assertType(users, _ as {users: User[]});
       expect(users).toEqual({users: []});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null, null);
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null, {"name": "red"});
 
       mockFetcher.mockClear();
       mockFetcher.mockReturnValueOnce({id: 'fred', name: 'Fred', age: 42});

--- a/src/__tests__/typed-request.test.ts
+++ b/src/__tests__/typed-request.test.ts
@@ -50,7 +50,7 @@ describe('typed requests', () => {
       assertType(users, _ as {users: User[]});
       expect(users).toEqual({users: []});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null, {"name": "red"});
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null, {name: 'red'});
 
       mockFetcher.mockClear();
       mockFetcher.mockReturnValueOnce({id: 'fred', name: 'Fred', age: 42});
@@ -72,7 +72,12 @@ describe('typed requests', () => {
       assertType(newUser, _ as User);
       expect(newUser).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42}, null);
+      expect(mockFetcher).toHaveBeenCalledWith(
+        '/users',
+        'post',
+        {name: 'Fred', age: 42},
+        null,
+      );
     });
 
     it('should provide a method-agnostic request method', async () => {
@@ -86,7 +91,12 @@ describe('typed requests', () => {
       assertType(newUser, _ as User);
       expect(newUser).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42}, null);
+      expect(mockFetcher).toHaveBeenCalledWith(
+        '/users',
+        'post',
+        {name: 'Fred', age: 42},
+        null,
+      );
     });
 
     it('should accept readonly objects in POST requests', async () => {

--- a/src/__tests__/typed-request.test.ts
+++ b/src/__tests__/typed-request.test.ts
@@ -50,7 +50,7 @@ describe('typed requests', () => {
       assertType(users, _ as {users: User[]});
       expect(users).toEqual({users: []});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null);
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null, null);
 
       mockFetcher.mockClear();
       mockFetcher.mockReturnValueOnce({id: 'fred', name: 'Fred', age: 42});
@@ -58,7 +58,7 @@ describe('typed requests', () => {
       assertType(user, _ as User);
       expect(user).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users/fred', 'get', null);
+      expect(mockFetcher).toHaveBeenCalledWith('/users/fred', 'get', null, null);
     });
 
     it('should generate POST requests', async () => {
@@ -72,7 +72,7 @@ describe('typed requests', () => {
       assertType(newUser, _ as User);
       expect(newUser).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42});
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42}, null);
     });
 
     it('should provide a method-agnostic request method', async () => {
@@ -86,7 +86,7 @@ describe('typed requests', () => {
       assertType(newUser, _ as User);
       expect(newUser).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42});
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42}, null);
     });
 
     it('should accept readonly objects in POST requests', async () => {

--- a/src/__tests__/typed-request.test.ts
+++ b/src/__tests__/typed-request.test.ts
@@ -46,9 +46,17 @@ describe('typed requests', () => {
       const getUserById = api.get('/users/:userId');
 
       mockFetcher.mockReturnValueOnce(Promise.resolve({users: []}));
-      const users = await getUsers({}, {name: 'red'});
-      assertType(users, _ as {users: User[]});
-      expect(users).toEqual({users: []});
+      const allUsers = await getUsers();
+      assertType(allUsers, _ as {users: User[]});
+      expect(allUsers).toEqual({users: []});
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null, null);
+
+      mockFetcher.mockClear();
+      mockFetcher.mockReturnValueOnce(Promise.resolve({users: []}));
+      const filteredUsers = await getUsers({}, {name: 'red'});
+      assertType(filteredUsers, _ as {users: User[]});
+      expect(filteredUsers).toEqual({users: []});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
       expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null, {name: 'red'});
 

--- a/src/__tests__/typed-request.test.ts
+++ b/src/__tests__/typed-request.test.ts
@@ -8,8 +8,11 @@ import {QueryUnion} from '../typed-request';
 describe('typed requests', () => {
   describe('apiUrlMaker', () => {
     it('should provide a union of query params available to all methods for a given endpoint', () => {
-      assertType(_ as QueryUnion<API, '/users'>, _ as {nameIncludes?: string; minAge?: number} | {suffix?: string})
-    })
+      assertType(
+        _ as QueryUnion<API, '/users'>,
+        _ as {nameIncludes?: string; minAge?: number} | {suffix?: string},
+      );
+    });
 
     it('should generate URLs without path params', () => {
       const urlMaker = apiUrlMaker<API>();
@@ -44,9 +47,11 @@ describe('typed requests', () => {
 
     it('should generate URLs with query params', () => {
       const urlMaker = apiUrlMaker<API>();
-      expect(urlMaker('/users')({}, {nameIncludes: 'Fre', minAge: 40})).toEqual('/users?nameIncludes=Fre&minAge=40')
-      expect(urlMaker('/users')({}, {suffix: 'Jr.'})).toEqual('/users?suffix=Jr.')
-    })
+      expect(urlMaker('/users')({}, {nameIncludes: 'Fre', minAge: 40})).toEqual(
+        '/users?nameIncludes=Fre&minAge=40',
+      );
+      expect(urlMaker('/users')({}, {suffix: 'Jr.'})).toEqual('/users?suffix=Jr.');
+    });
   });
 
   describe('default fetch implementation', () => {
@@ -130,11 +135,7 @@ describe('typed requests', () => {
       assertType(newUser, _ as User);
       expect(newUser).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith(
-        '/users',
-        'post',
-        {name: 'Fred', age: 42}
-      );
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42});
     });
 
     it('should provide a method-agnostic request method', async () => {
@@ -148,11 +149,7 @@ describe('typed requests', () => {
       assertType(newUser, _ as User);
       expect(newUser).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith(
-        '/users',
-        'post',
-        {name: 'Fred', age: 42}
-      );
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42});
     });
 
     it('should accept readonly objects in POST requests', async () => {

--- a/src/__tests__/typed-request.test.ts
+++ b/src/__tests__/typed-request.test.ts
@@ -42,9 +42,18 @@ describe('typed requests', () => {
     it('should generate GET requests', async () => {
       const mockFetcher = jest.fn();
       const api = typedApi<API>({fetch: mockFetcher});
+      const getRandom = api.get('/random');
       const getUsers = api.get('/users');
       const getUserById = api.get('/users/:userId');
 
+      mockFetcher.mockReturnValueOnce(Promise.resolve({random: 7}));
+      const random = await getRandom();
+      assertType(random, _ as {random: number});
+      expect(random).toEqual({random: 7});
+      expect(mockFetcher).toHaveBeenCalledTimes(1);
+      expect(mockFetcher).toHaveBeenCalledWith('/random', 'get', null, null);
+
+      mockFetcher.mockClear();
       mockFetcher.mockReturnValueOnce(Promise.resolve({users: []}));
       const allUsers = await getUsers();
       assertType(allUsers, _ as {users: User[]});

--- a/src/__tests__/typed-request.test.ts
+++ b/src/__tests__/typed-request.test.ts
@@ -54,11 +54,11 @@ describe('typed requests', () => {
 
       mockFetcher.mockClear();
       mockFetcher.mockReturnValueOnce(Promise.resolve({users: []}));
-      const filteredUsers = await getUsers({}, {name: 'red'});
+      const filteredUsers = await getUsers({}, {nameIncludes: 'red'});
       assertType(filteredUsers, _ as {users: User[]});
       expect(filteredUsers).toEqual({users: []});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null, {name: 'red'});
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'get', null, {nameIncludes: 'red'});
 
       mockFetcher.mockClear();
       mockFetcher.mockReturnValueOnce({id: 'fred', name: 'Fred', age: 42});

--- a/src/__tests__/typed-request.test.ts
+++ b/src/__tests__/typed-request.test.ts
@@ -38,6 +38,36 @@ describe('typed requests', () => {
     });
   });
 
+  describe('default fetch implementation', () => {
+    let mockFetch: jest.Mock;
+    beforeEach(() => {
+      mockFetch = jest.fn();
+      global.fetch = mockFetch;
+    });
+
+    it('should have correct request data', async () => {
+      const api = typedApi<API>();
+      const getUsers = api.get('/users');
+
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({json: () => Promise.resolve({users: []})}),
+      );
+
+      const users = await getUsers({}, {minAge: 42});
+      assertType(users, _ as {users: User[]});
+      expect(users).toEqual({users: []});
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith('/users?minAge=42', {
+        method: 'get',
+        body: 'null',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+  });
+
   describe('typed API', () => {
     it('should generate GET requests', async () => {
       const mockFetcher = jest.fn();

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -28,7 +28,7 @@ test('TypedRouter', async () => {
 
   router.get('/random', async () => ({random: 7}));
 
-  router.get('/users', async (_params, _req, _res, {nameIncludes, minAge}) => ({
+  router.get('/users', async (_params, {query: {nameIncludes, minAge}}, _res) => ({
     users: users.filter(
       user =>
         (!nameIncludes || user.name.includes(nameIncludes)) && (!minAge || user.age >= minAge),
@@ -199,7 +199,7 @@ test('Throwing HTTPError should set status code', async () => {
     }
   }
 
-  router.get('/users', async (_params, req, res, query) => {
+  router.get('/users', async () => {
     return {users: [] as User[]};
   });
 

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -31,8 +31,7 @@ test('TypedRouter', async () => {
   router.get('/users', async (_params, _req, _res, {nameIncludes, minAge}) => ({
     users: users.filter(
       user =>
-        (nameIncludes ? user.name.includes(nameIncludes) : true) &&
-        (minAge ? user.age >= minAge : true),
+        (!nameIncludes || user.name.includes(nameIncludes)) && (!minAge || user.age >= minAge),
     ),
   }));
 

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -26,6 +26,8 @@ test('TypedRouter', async () => {
     },
   ];
 
+  router.get('/random', async () => ({random: 7}));
+
   router.get('/users', async (_params, _req, _res, {nameIncludes, minAge}) => ({
     users: users.filter(
       user =>

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -26,7 +26,9 @@ test('TypedRouter', async () => {
     },
   ];
 
-  router.get('/users', async () => ({users}));
+  router.get('/users', async (_params, _req, _res, {name}) => ({
+    users: users.filter(user => user.name.includes(name)),
+  }));
 
   router.post('/users', async ({}, user, request, response) => {
     assertType(user, _ as {age: number; name: string});
@@ -85,8 +87,8 @@ test('TypedRouter', async () => {
 
   const api = request(app);
 
-  const responseUsers = await api.get('/users').expect(200);
-  expect(responseUsers.body).toEqual({users});
+  const responseUsers = await api.get('/users?name=red').expect(200);
+  expect(responseUsers.body).toEqual({users: [users[0]]});
 
   const fredResponse = await api.get('/users/fred').expect(200);
   expect(fredResponse.body).toEqual({id: 'fred', name: 'Fred', age: 42});

--- a/src/api-spec.ts
+++ b/src/api-spec.ts
@@ -1,14 +1,15 @@
-export interface Endpoint<Request, Response> {
+export interface Endpoint<Request, Response, Query = null> {
   request: Request;
   response: Response;
+  query: Query;
 }
 
-export type GetEndpoint<Response> = Endpoint<null, Response>;
+export type GetEndpoint<Response, Query = null> = Endpoint<null, Response, Query>;
 
 export type HTTPVerb = 'get' | 'post' | 'put' | 'delete' | 'patch';
 
 export interface APISpec {
   [path: string]: {
-    [method in HTTPVerb]?: Endpoint<any, any>;
+    [method in HTTPVerb]?: Endpoint<any, any, any>;
   };
 }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -111,7 +111,7 @@ export function apiSpecToOpenApi(apiSpec: any, options?: Options): any {
             name: key,
             in: 'query',
             schema: value,
-          })
+          });
         }
       }
 

--- a/src/typed-request.ts
+++ b/src/typed-request.ts
@@ -22,11 +22,11 @@ export interface Options {
   /** Prefix to add to all API endpoints (e.g. /api/v0) */
   prefix?: string;
   /** Function to use for fetching. Defaults to browser fetch. */
-  fetch?: (url: string, method: HTTPVerb, payload: unknown) => Promise<unknown>;
+  fetch?: (url: string, method: HTTPVerb, payload: unknown, query?: Record<string, unknown>) => Promise<unknown>;
 }
 
-export async function fetchJson(url: string, method: HTTPVerb, payload: unknown) {
-  const response = await fetch(url, {
+export async function fetchJson(url: string, method: HTTPVerb, payload: unknown, query?: Record<string, string>) {
+  const response = await fetch(url + (query ? new URLSearchParams(query) : ''), {
     method,
     headers: {
       Accept: 'application/json',
@@ -52,9 +52,10 @@ export function typedApi<API>(options?: Options) {
     type Endpoint = SafeKey<API[Path], Method>;
     type Request = DeepReadonly<SafeKey<Endpoint, 'request'>>;
     type Response = SafeKey<Endpoint, 'response'>;
+    type Query = SafeKey<Endpoint, 'query'>
     const makeUrl = urlMaker(endpoint);
-    return (queryParams: Params, body: Request): Promise<Response> =>
-      fetcher((makeUrl as any)(queryParams), method, body) as Promise<Response>;
+    return (queryParams: Params, body: Request, query?: Query): Promise<Response> =>
+      fetcher((makeUrl as any)(queryParams), method, body, query ?? null as any) as Promise<Response>;
   };
 
   const requestWithoutBody = <Method extends HTTPVerb>(method: Method) => <
@@ -66,7 +67,7 @@ export function typedApi<API>(options?: Options) {
     type Endpoint = SafeKey<API[Path], Method>;
     type Response = SafeKey<Endpoint, 'response'>;
     return (...params: ParamsList): Promise<Response> =>
-      requestWithBody(method)(endpoint)(params?.[0] as any, null as any);
+      requestWithBody(method)(endpoint)(params?.[0] as any, null as any, null as any);
   };
 
   return {

--- a/src/typed-request.ts
+++ b/src/typed-request.ts
@@ -28,7 +28,7 @@ export interface Options {
     url: string,
     method: HTTPVerb,
     payload: unknown,
-    query?: Record<string, unknown>,
+    query?: Record<string, string>,
   ) => Promise<unknown>;
 }
 

--- a/src/typed-request.ts
+++ b/src/typed-request.ts
@@ -20,12 +20,19 @@ type ParamVarArgs<Params, Query> = DeepReadonly<
 >;
 
 type QueryForMethod<Endpoint, Method extends keyof Endpoint> = SafeKey<
-  SafeKey<Endpoint, Method>,
+  Endpoint[Method],
   'query'
 >;
 
+type MergedQueryParams<API, Path extends keyof API> = {
+  [K in keyof API[Path]]: (x: SafeKey<API[Path][K], 'query'>) => void;
+}[keyof API[Path]] extends (x: infer I) => void
+  ? {[K in keyof I]: I[K]}
+  : never;
+
 type QueryIntersection<API, Path extends keyof API, P = API[Path]> = Pick<
-  SafeKey<P[keyof P], 'query'>,
+  MergedQueryParams<API, Path>,
+  // @ts-expect-error Unable to do this generically but actually does work. TS issue?
   keyof SafeKey<P[keyof P], 'query'>
 >;
 

--- a/src/typed-request.ts
+++ b/src/typed-request.ts
@@ -47,7 +47,7 @@ export async function fetchJson(
   payload: unknown,
   query?: Record<string, string>,
 ) {
-  const response = await fetch(url + (query ? new URLSearchParams(query) : ''), {
+  const response = await fetch(url + (query ? '?' + new URLSearchParams(query) : ''), {
     method,
     headers: {
       Accept: 'application/json',

--- a/src/typed-router.ts
+++ b/src/typed-router.ts
@@ -46,7 +46,6 @@ const registerWithBody = <Method extends HTTPVerb, API>(
     body: SafeKey<Spec, 'request'>,
     request: ExpressRequest<Path, Spec>,
     response: ExpressResponse<Spec>,
-    query: ExpressRequest<Path, Spec>['query']
   ) => Promise<Spec extends AnyEndpoint ? Spec['response'] : never>,
 ) => {
   router.registerEndpoint(method, route as any, handler as any);
@@ -64,11 +63,10 @@ const registerWithoutBody = <Method extends HTTPVerb, API>(
     params: ExtractRouteParams<Path>,
     request: ExpressRequest<Path, Spec>,
     response: ExpressResponse<Spec>,
-    query: ExpressRequest<Path, Spec>['query']
   ) => Promise<Spec extends AnyEndpoint ? Spec['response'] : never>,
 ) => {
   router.registerEndpoint(method, route as any, (params, _, request, response) =>
-    handler(params as any, request as any, response as any, request.query as any),
+    handler(params as any, request as any, response as any),
   );
 };
 
@@ -109,7 +107,6 @@ export class TypedRouter<API> {
       body: SafeKey<Spec, 'request'>,
       request: ExpressRequest<Path, Spec>,
       response: ExpressResponse<Spec>,
-      query: ExpressRequest<Path, Spec>['query']
     ) => Promise<Spec extends AnyEndpoint ? Spec['response'] : never>,
   ) {
     const bodyValidate = this.getValidator(route, method, 'request');
@@ -140,7 +137,7 @@ export class TypedRouter<API> {
         console.debug(method, route, 'params=', req.params, 'body=', body, 'query=', query);
       }
 
-      handler(req.params as any, body, req as any, response, req.query as any)
+      handler(req.params as any, body, req as any, response)
         .then(responseObject => {
           if (responseObject === null) {
             // nothing to do. This can happen if the response redirected, say.

--- a/src/typed-router.ts
+++ b/src/typed-router.ts
@@ -195,7 +195,7 @@ export class TypedRouter<API> {
       } else {
         // Create a new AJV validate for inline object types.
         // This assumes these will never reference other type definitions.
-        const requestAjv = new Ajv();
+        const requestAjv = new Ajv({ coerceTypes: property === 'query' });
         validate = requestAjv.compile(validateType);
       }
       if (!validate) {


### PR DESCRIPTION
Hey @danvk, loving crosswalk. Found that I needed query parameters in my application and figured I'd take a crack at implementing it. Let me know if you see anything concerning or have any questions!

I'd love to move the query param to the beginning of the handler args (ie. [params, body, query, req, res]) but I wanted to make sure this was as unobtrusive (and non-breaking) as possible so I made it an optional last parameter.

As a side note, I added `--noExtraProps` to the README because it appears you were using it during testing, and I think it makes a ton of sense as the default.

Thanks,
Carter

Closes #5 