### PR TITLE
Support complex inline types

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "lint": "prettier --check src/**/*.ts",
     "prettier": "prettier --write src/**/*.ts",
-    "update-test-schema": "typescript-json-schema --required --strictNullChecks src/__tests__/api.ts API --out src/__tests__/api.schema.json"
+    "update-test-schema": "typescript-json-schema --required --noExtraProps --strictNullChecks src/__tests__/api.ts API --out src/__tests__/api.schema.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prepare": "install-peers",
     "test": "jest",
     "lint": "prettier --check src/**/*.ts",
-    "prettier": "prettier --write src/**/*.ts"
+    "prettier": "prettier --write src/**/*.ts",
+    "update-test-schema": "typescript-json-schema --required --strictNullChecks src/__tests__/api.ts API --out src/__tests__/api.schema.json"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -59,6 +59,42 @@ Object {
   },
   "paths": Object {
     "/complex": Object {
+      "patch": Object {
+        "parameters": Array [
+          Object {
+            "in": "body",
+            "name": "body",
+            "schema": Object {
+              "additionalProperties": false,
+              "properties": Object {
+                "age": Object {
+                  "type": "number",
+                },
+                "id": Object {
+                  "type": "string",
+                },
+                "name": Object {
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "age",
+                "id",
+                "name",
+              ],
+              "type": "object",
+            },
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "schema": Object {
+              "$ref": "#/definitions/User",
+            },
+          },
+        },
+        "summary": undefined,
+      },
       "post": Object {
         "parameters": Array [
           Object {

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -4,7 +4,6 @@ exports[`Open API integration should have the expected endpoints: open-api 1`] =
 Object {
   "definitions": Object {
     "Partial<Pick<User,\\"name\\"|\\"age\\">>": Object {
-      "additionalProperties": false,
       "properties": Object {
         "age": Object {
           "type": "number",
@@ -16,7 +15,6 @@ Object {
       "type": "object",
     },
     "Pick<User,\\"name\\"|\\"age\\">": Object {
-      "additionalProperties": false,
       "properties": Object {
         "age": Object {
           "type": "number",
@@ -32,7 +30,6 @@ Object {
       "type": "object",
     },
     "User": Object {
-      "additionalProperties": false,
       "properties": Object {
         "age": Object {
           "type": "number",
@@ -58,12 +55,47 @@ Object {
     "version": "",
   },
   "paths": Object {
+    "/complex": Object {
+      "post": Object {
+        "parameters": Array [
+          Object {
+            "in": "body",
+            "name": "body",
+            "schema": Object {
+              "properties": Object {
+                "user": Object {
+                  "anyOf": Array [
+                    Object {
+                      "$ref": "#/definitions/User",
+                    },
+                    Object {
+                      "type": "null",
+                    },
+                  ],
+                },
+              },
+              "required": Array [
+                "user",
+              ],
+              "type": "object",
+            },
+          },
+        ],
+        "responses": Object {
+          "200": Object {
+            "schema": Object {
+              "$ref": "#/definitions/User",
+            },
+          },
+        },
+        "summary": undefined,
+      },
+    },
     "/users": Object {
       "get": Object {
         "responses": Object {
           "200": Object {
             "schema": Object {
-              "additionalProperties": false,
               "properties": Object {
                 "users": Object {
                   "items": Object {
@@ -179,7 +211,6 @@ Object {
             "in": "body",
             "name": "body",
             "schema": Object {
-              "additionalProperties": false,
               "properties": Object {
                 "age": Object {
                   "type": "number",

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Open API integration should have the expected endpoints: open-api 1`] =
 Object {
   "definitions": Object {
     "Partial<Pick<User,\\"name\\"|\\"age\\">>": Object {
+      "additionalProperties": false,
       "properties": Object {
         "age": Object {
           "type": "number",
@@ -15,6 +16,7 @@ Object {
       "type": "object",
     },
     "Pick<User,\\"name\\"|\\"age\\">": Object {
+      "additionalProperties": false,
       "properties": Object {
         "age": Object {
           "type": "number",
@@ -30,6 +32,7 @@ Object {
       "type": "object",
     },
     "User": Object {
+      "additionalProperties": false,
       "properties": Object {
         "age": Object {
           "type": "number",
@@ -62,6 +65,7 @@ Object {
             "in": "body",
             "name": "body",
             "schema": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "user": Object {
                   "anyOf": Array [
@@ -96,6 +100,7 @@ Object {
         "responses": Object {
           "200": Object {
             "schema": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "users": Object {
                   "items": Object {
@@ -211,6 +216,7 @@ Object {
             "in": "body",
             "name": "body",
             "schema": Object {
+              "additionalProperties": false,
               "properties": Object {
                 "age": Object {
                   "type": "number",

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -1,7 +1,9 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
     "definitions": {
         "Endpoint<Partial<Pick<User,\"name\"|\"age\">>,User>": {
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "$ref": "#/definitions/Partial<Pick<User,\"name\"|\"age\">>"
@@ -17,6 +19,7 @@
             "type": "object"
         },
         "Endpoint<Pick<User,\"name\"|\"age\">,User>": {
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "$ref": "#/definitions/Pick<User,\"name\"|\"age\">"
@@ -32,8 +35,10 @@
             "type": "object"
         },
         "Endpoint<{name?:string|undefined;age?:number|undefined;},User>": {
+            "additionalProperties": false,
             "properties": {
                 "request": {
+                    "additionalProperties": false,
                     "properties": {
                         "age": {
                             "type": "number"
@@ -55,8 +60,10 @@
             "type": "object"
         },
         "Endpoint<{user:User|null;},User>": {
+            "additionalProperties": false,
             "properties": {
                 "request": {
+                    "additionalProperties": false,
                     "properties": {
                         "user": {
                             "anyOf": [
@@ -85,6 +92,7 @@
             "type": "object"
         },
         "Endpoint<{},User>": {
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "properties": {
@@ -102,6 +110,7 @@
             "type": "object"
         },
         "GetEndpoint<User>": {
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "type": "null"
@@ -117,11 +126,13 @@
             "type": "object"
         },
         "GetEndpoint<{users:User[];}>": {
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "type": "null"
                 },
                 "response": {
+                    "additionalProperties": false,
                     "properties": {
                         "users": {
                             "items": {
@@ -143,6 +154,7 @@
             "type": "object"
         },
         "Partial<Pick<User,\"name\"|\"age\">>": {
+            "additionalProperties": false,
             "properties": {
                 "age": {
                     "type": "number"
@@ -154,6 +166,7 @@
             "type": "object"
         },
         "Pick<User,\"name\"|\"age\">": {
+            "additionalProperties": false,
             "properties": {
                 "age": {
                     "type": "number"
@@ -169,6 +182,7 @@
             "type": "object"
         },
         "User": {
+            "additionalProperties": false,
             "properties": {
                 "age": {
                     "type": "number"
@@ -190,6 +204,7 @@
     },
     "properties": {
         "/complex": {
+            "additionalProperties": false,
             "properties": {
                 "post": {
                     "$ref": "#/definitions/Endpoint<{user:User|null;},User>"
@@ -201,6 +216,7 @@
             "type": "object"
         },
         "/users": {
+            "additionalProperties": false,
             "properties": {
                 "get": {
                     "$ref": "#/definitions/GetEndpoint<{users:User[];}>",
@@ -218,6 +234,7 @@
             "type": "object"
         },
         "/users/:userId": {
+            "additionalProperties": false,
             "properties": {
                 "delete": {
                     "$ref": "#/definitions/Endpoint<{},User>"

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -18,6 +18,39 @@
             ],
             "type": "object"
         },
+        "Endpoint<Pick<User,\"name\"|\"age\">&{id:string;},User>": {
+            "additionalProperties": false,
+            "properties": {
+                "request": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "age": {
+                            "type": "number"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "age",
+                        "id",
+                        "name"
+                    ],
+                    "type": "object"
+                },
+                "response": {
+                    "$ref": "#/definitions/User"
+                }
+            },
+            "required": [
+                "request",
+                "response"
+            ],
+            "type": "object"
+        },
         "Endpoint<Pick<User,\"name\"|\"age\">,User>": {
             "additionalProperties": false,
             "properties": {
@@ -206,11 +239,15 @@
         "/complex": {
             "additionalProperties": false,
             "properties": {
+                "patch": {
+                    "$ref": "#/definitions/Endpoint<Pick<User,\"name\"|\"age\">&{id:string;},User>"
+                },
                 "post": {
                     "$ref": "#/definitions/Endpoint<{user:User|null;},User>"
                 }
             },
             "required": [
+                "patch",
                 "post"
             ],
             "type": "object"

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -1,9 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "additionalProperties": false,
     "definitions": {
         "Endpoint<Partial<Pick<User,\"name\"|\"age\">>,User>": {
-            "additionalProperties": false,
             "properties": {
                 "request": {
                     "$ref": "#/definitions/Partial<Pick<User,\"name\"|\"age\">>"
@@ -19,7 +17,6 @@
             "type": "object"
         },
         "Endpoint<Pick<User,\"name\"|\"age\">,User>": {
-            "additionalProperties": false,
             "properties": {
                 "request": {
                     "$ref": "#/definitions/Pick<User,\"name\"|\"age\">"
@@ -35,10 +32,8 @@
             "type": "object"
         },
         "Endpoint<{name?:string|undefined;age?:number|undefined;},User>": {
-            "additionalProperties": false,
             "properties": {
                 "request": {
-                    "additionalProperties": false,
                     "properties": {
                         "age": {
                             "type": "number"
@@ -59,8 +54,37 @@
             ],
             "type": "object"
         },
+        "Endpoint<{user:User|null;},User>": {
+            "properties": {
+                "request": {
+                    "properties": {
+                        "user": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/User"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "user"
+                    ],
+                    "type": "object"
+                },
+                "response": {
+                    "$ref": "#/definitions/User"
+                }
+            },
+            "required": [
+                "request",
+                "response"
+            ],
+            "type": "object"
+        },
         "Endpoint<{},User>": {
-            "additionalProperties": false,
             "properties": {
                 "request": {
                     "properties": {
@@ -78,7 +102,6 @@
             "type": "object"
         },
         "GetEndpoint<User>": {
-            "additionalProperties": false,
             "properties": {
                 "request": {
                     "type": "null"
@@ -94,13 +117,11 @@
             "type": "object"
         },
         "GetEndpoint<{users:User[];}>": {
-            "additionalProperties": false,
             "properties": {
                 "request": {
                     "type": "null"
                 },
                 "response": {
-                    "additionalProperties": false,
                     "properties": {
                         "users": {
                             "items": {
@@ -122,7 +143,6 @@
             "type": "object"
         },
         "Partial<Pick<User,\"name\"|\"age\">>": {
-            "additionalProperties": false,
             "properties": {
                 "age": {
                     "type": "number"
@@ -134,7 +154,6 @@
             "type": "object"
         },
         "Pick<User,\"name\"|\"age\">": {
-            "additionalProperties": false,
             "properties": {
                 "age": {
                     "type": "number"
@@ -150,7 +169,6 @@
             "type": "object"
         },
         "User": {
-            "additionalProperties": false,
             "properties": {
                 "age": {
                     "type": "number"
@@ -171,8 +189,18 @@
         }
     },
     "properties": {
+        "/complex": {
+            "properties": {
+                "post": {
+                    "$ref": "#/definitions/Endpoint<{user:User|null;},User>"
+                }
+            },
+            "required": [
+                "post"
+            ],
+            "type": "object"
+        },
         "/users": {
-            "additionalProperties": false,
             "properties": {
                 "get": {
                     "$ref": "#/definitions/GetEndpoint<{users:User[];}>",
@@ -190,7 +218,6 @@
             "type": "object"
         },
         "/users/:userId": {
-            "additionalProperties": false,
             "properties": {
                 "delete": {
                     "$ref": "#/definitions/Endpoint<{},User>"
@@ -216,6 +243,7 @@
         }
     },
     "required": [
+        "/complex",
         "/users",
         "/users/:userId"
     ],

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -23,6 +23,7 @@ export interface API {
     delete: Endpoint<{}, User>;
   };
   '/complex': {
+    // This endpoint references an interface from an inline type, see issue #10.
     post: Endpoint<{user: User | null}, User>;
   }
 }

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -22,4 +22,7 @@ export interface API {
     put: Endpoint<{name?: string; age?: number}, User>;
     delete: Endpoint<{}, User>;
   };
+  '/complex': {
+    post: Endpoint<{user: User | null}, User>;
+  }
 }

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -27,5 +27,5 @@ export interface API {
     post: Endpoint<{user: User | null}, User>;
     // This endpoint is used to test that intersection types work as expected.
     patch: Endpoint<CreateUserRequest & {id: string}, User>;
-  }
+  };
 }

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -25,5 +25,7 @@ export interface API {
   '/complex': {
     // This endpoint references an interface from an inline type, see issue #10.
     post: Endpoint<{user: User | null}, User>;
+    // This endpoint is used to test that intersection types work as expected.
+    patch: Endpoint<CreateUserRequest & {id: string}, User>;
   }
 }

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -86,6 +86,9 @@ test('TypedRouter', async () => {
     assertType(body.user, _ as User | null);
     return users[0];
   });
+  router.patch('/complex', async ({}, body) => {
+    return users[0];
+  });
 
   const api = request(app);
 
@@ -184,6 +187,34 @@ test('TypedRouter', async () => {
     .send({user: {id: 'id', name: 'name', age: 42}})
     .set('Accept', 'application/json')
     .expect(200);
+
+  await api
+    .patch('/complex')
+    .send({id: 'id', name: 'name', age: 42})
+    .set('Accept', 'application/json')
+    .expect(200);
+
+  await api
+    .patch('/complex')
+    .send({id: 'id', name: 'name'})
+    .set('Accept', 'application/json')
+    .expect(400)
+    .expect(response => {
+      expect(response.body.error).toMatchInlineSnapshot(
+        `"data should have required property 'age'"`,
+      );
+    });
+
+  await api
+    .patch('/complex')
+    .send({name: 'name', age: 42})
+    .set('Accept', 'application/json')
+    .expect(400)
+    .expect(response => {
+      expect(response.body.error).toMatchInlineSnapshot(
+        `"data should have required property 'id'"`,
+      );
+    });
 
   router.assertAllRoutesRegistered();
 });

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -82,6 +82,10 @@ test('TypedRouter', async () => {
   router.registerEndpoint('patch', '/users/:userId', async () => {
     throw new Error('Not implemented');
   });
+  router.post('/complex', async ({}, body) => {
+    assertType(body.user, _ as User | null);
+    throw new Error('Not implemented');
+  });
 
   const api = request(app);
 

--- a/src/typed-router.ts
+++ b/src/typed-router.ts
@@ -170,9 +170,6 @@ export class TypedRouter<API> {
       requestType = requestType.$ref; // allow either references or inline types
     } else if (requestType.type && requestType.type === 'null') {
       requestType = null; // no request body, no validation
-    } else if (requestType.allOf) {
-      // TODO(danvk): figure out how to make ajv understand these.
-      throw new Error('Intersection types in APIs are not supported yet.');
     }
 
     if (requestType && this.ajv) {
@@ -183,7 +180,11 @@ export class TypedRouter<API> {
         // Create a new AJV validate for inline object types.
         // This assumes these will never reference other type definitions.
         const requestAjv = new Ajv();
-        validate = requestAjv.compile(requestType);
+        validate = requestAjv.compile({
+          '$schema': apiSchema.$schema,
+          definitions: apiSchema.definitions,
+          ...requestType
+        });
       }
       if (!validate) {
         throw new Error(`Unable to get schema for '${requestType}'`);


### PR DESCRIPTION
Fixes #10 

The fix turns out to be pretty simple: instead of creating an Ajv with just the request type, we create one with the request type _and_ all the type definitions. This also gets us support for intersection types in requests.