### PR TITLE
Correctly name version as 3.1.0

### DIFF
--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -199,7 +199,7 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
     "title": "Generated API",
     "version": "",
   },
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "paths": {
     "/complex": {
       "patch": {

--- a/src/__tests__/openapi.test.ts
+++ b/src/__tests__/openapi.test.ts
@@ -13,7 +13,7 @@ describe('Open API integration', () => {
 
 describe('Open API V3', () => {
   it('should have the expected endpoints', () => {
-    const openApi = apiSpecToOpenApi(apiSchemaJson, {version: '3.0'});
+    const openApi = apiSpecToOpenApi(apiSchemaJson, {version: '3.1.0'});
     expect(openApi).toMatchSnapshot('open-api-v3');
   });
 

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -81,7 +81,7 @@ export interface Options {
   host?: string;
   basePath?: string;
   schemes?: ('http' | 'https')[];
-  version?: '2.0' | '3.0';
+  version?: '2.0' | '3.1.0';
 }
 
 function extractPathParams(path: string): PathParam[] {
@@ -482,7 +482,7 @@ function apiSpecToOpenApi3(apiSpec: any, options?: Options): any {
   delete options?.version;
 
   return {
-    openapi: '3.0.0',
+    openapi: '3.1.0',
     info: {
       title: 'Generated API',
       description: 'testing testing',


### PR DESCRIPTION
as we generated a spec w/ `const` and it passed the 3.1.0 validator but not the 3.0.0 validator.